### PR TITLE
Implement pairwise preference training

### DIFF
--- a/rl4co/models/__init__.py
+++ b/rl4co/models/__init__.py
@@ -26,8 +26,8 @@ from rl4co.models.zoo.amppo import AMPPO
 from rl4co.models.zoo.dact import DACT, DACTPolicy
 from rl4co.models.zoo.deepaco import DeepACO, DeepACOPolicy
 from rl4co.models.zoo.eas import EAS, EASEmb, EASLay
-from rl4co.models.zoo.glop import GLOP, GLOPPolicy
 from rl4co.models.zoo.gfacs import GFACS, GFACSPolicy
+from rl4co.models.zoo.glop import GLOP, GLOPPolicy
 from rl4co.models.zoo.ham import (
     HeterogeneousAttentionModel,
     HeterogeneousAttentionModelPolicy,
@@ -47,5 +47,6 @@ from rl4co.models.zoo.nargnn import NARGNNPolicy
 from rl4co.models.zoo.neuopt import NeuOpt, NeuOptPolicy
 from rl4co.models.zoo.polynet import PolyNet
 from rl4co.models.zoo.pomo import POMO
+from rl4co.models.zoo.prefdce import PreferenceDCE
 from rl4co.models.zoo.ptrnet import PointerNetwork, PointerNetworkPolicy
 from rl4co.models.zoo.symnco import SymNCO, SymNCOPolicy

--- a/rl4co/models/zoo/__init__.py
+++ b/rl4co/models/zoo/__init__.py
@@ -27,5 +27,6 @@ from rl4co.models.zoo.nargnn import NARGNNPolicy
 from rl4co.models.zoo.neuopt import NeuOpt, NeuOptPolicy
 from rl4co.models.zoo.polynet import PolyNet
 from rl4co.models.zoo.pomo import POMO
+from rl4co.models.zoo.prefdce import PreferenceDCE
 from rl4co.models.zoo.ptrnet import PointerNetwork, PointerNetworkPolicy
 from rl4co.models.zoo.symnco import SymNCO, SymNCOPolicy

--- a/rl4co/models/zoo/prefdce/__init__.py
+++ b/rl4co/models/zoo/prefdce/__init__.py
@@ -1,0 +1,3 @@
+from .model import PreferenceDCE, build_pref_matrices
+
+__all__ = ["PreferenceDCE", "build_pref_matrices"]

--- a/rl4co/models/zoo/prefdce/model.py
+++ b/rl4co/models/zoo/prefdce/model.py
@@ -1,0 +1,102 @@
+import torch
+import torch.nn as nn
+
+from tensordict import TensorDict
+
+from rl4co.envs.common.base import RL4COEnvBase
+from rl4co.models.rl import REINFORCE
+from rl4co.utils.ops import unbatchify
+
+
+def build_pref_matrices(
+    rewards: torch.Tensor,
+    logps: torch.Tensor,
+    beta: float,
+    alpha: float,
+    fast: bool = True,
+):
+    """Compute DCE advantages.
+
+    Args:
+        rewards: [batch, m] reward tensor
+        logps: [batch, m] log likelihood tensor
+        beta: scaling for reward differences
+        alpha: scaling for logprob differences
+        fast: whether to use the O(m) per sample method
+    Returns:
+        advantage: [batch, m] tensor
+        diff: [batch, m, m] full difference matrix if fast=False else None
+    """
+    if fast:
+        B, m = rewards.shape
+        advantage = torch.zeros_like(rewards)
+        for k in range(m):
+            Rdiff_k = rewards[:, k].unsqueeze(-1) - rewards
+            Ldiff_k = logps[:, k].unsqueeze(-1) - logps
+            q_k = torch.sigmoid(beta * Rdiff_k)
+            p_k = torch.sigmoid(alpha * Ldiff_k)
+            diff = p_k - q_k
+            diff[:, k] = 0
+            advantage[:, k] = 2 * diff.sum(dim=1)
+        return advantage, None
+
+    Rdiff = rewards.unsqueeze(-1) - rewards.unsqueeze(-2)
+    Ldiff = logps.unsqueeze(-1) - logps.unsqueeze(-2)
+    q = torch.sigmoid(beta * Rdiff)
+    p = torch.sigmoid(alpha * Ldiff)
+    diff = p - q
+    diff.diagonal(dim1=-2, dim2=-1).zero_()
+    advantage = 2 * diff.sum(dim=-1)
+    return advantage, diff
+
+
+class PreferenceDCE(REINFORCE):
+    """REINFORCE variant with pairwise preference cross entropy."""
+
+    def __init__(
+        self,
+        env: RL4COEnvBase,
+        policy: nn.Module,
+        num_samples: int = 8,
+        alpha: float = 1.0,
+        beta: float = 1.0,
+        fast_dce: bool = True,
+        **kwargs,
+    ):
+        super().__init__(env, policy, baseline="no", **kwargs)
+        self.num_samples = num_samples
+        self.alpha = alpha
+        self.beta = beta
+        self.fast_dce = fast_dce
+
+    def shared_step(
+        self,
+        batch: TensorDict,
+        batch_idx: int,
+        phase: str,
+        dataloader_idx: int | None = None,
+    ):
+        td = self.env.reset(batch)
+        out = self.policy(td, self.env, phase=phase, num_samples=self.num_samples)
+        if phase == "train":
+            out["loss"] = self.calculate_loss(td, batch, out)
+        metrics = self.log_metrics(out, phase, dataloader_idx=dataloader_idx)
+        return {"loss": out.get("loss", None), **metrics}
+
+    def calculate_loss(
+        self,
+        td: TensorDict,
+        batch: TensorDict,
+        policy_out: dict,
+        reward: torch.Tensor | None = None,
+        log_likelihood: torch.Tensor | None = None,
+    ):
+        reward = policy_out["reward"]
+        log_likelihood = policy_out["log_likelihood"]
+        reward = unbatchify(reward, self.num_samples)
+        log_likelihood = unbatchify(log_likelihood, self.num_samples)
+        advantage, _ = build_pref_matrices(
+            reward, log_likelihood, self.beta, self.alpha, fast=self.fast_dce
+        )
+        loss = -(advantage * log_likelihood).mean()
+        return loss

--- a/tests/test_prefdce.py
+++ b/tests/test_prefdce.py
@@ -1,0 +1,30 @@
+import torch
+
+from rl4co.envs import TSPEnv
+from rl4co.models.zoo import AttentionModelPolicy
+from rl4co.models.zoo.prefdce.model import PreferenceDCE, build_pref_matrices
+from rl4co.utils import RL4COTrainer
+
+
+def test_pref_matrix_fast_equivalence():
+    rewards = torch.randn(1, 8)
+    logps = torch.randn(1, 8)
+    full, _ = build_pref_matrices(rewards, logps, beta=1.0, alpha=1.0, fast=False)
+    fast, _ = build_pref_matrices(rewards, logps, beta=1.0, alpha=1.0, fast=True)
+    assert torch.allclose(full, fast, atol=1e-6)
+
+
+def test_preference_dce_train(tmp_path):
+    env = TSPEnv(generator_params=dict(num_loc=20))
+    policy = AttentionModelPolicy(env_name=env.name)
+    model = PreferenceDCE(
+        env,
+        policy,
+        num_samples=4,
+        train_data_size=10,
+        val_data_size=10,
+        test_data_size=10,
+    )
+    trainer = RL4COTrainer(max_epochs=1, devices=1, accelerator="cpu")
+    trainer.fit(model)
+    trainer.test(model)


### PR DESCRIPTION
## Summary
- add PreferenceDCE algorithm implementing pairwise cross-entropy loss
- export PreferenceDCE via model registries
- test fast vs full matrix equivalence and a minimal training loop

## Testing
- `ruff check rl4co/models/zoo/prefdce/model.py tests/test_prefdce.py rl4co/models/zoo/prefdce/__init__.py rl4co/models/zoo/__init__.py rl4co/models/__init__.py` *(passes)*
- `black rl4co/models/zoo/prefdce/model.py tests/test_prefdce.py rl4co/models/zoo/prefdce/__init__.py rl4co/models/zoo/__init__.py rl4co/models/__init__.py` *(reformatted)*
- `pytest -q tests/test_prefdce.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_b_687ddfdd78e88326a166bd3fb6920bfa